### PR TITLE
Change to default port

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,5 +11,5 @@ class redis::config {
   $datadir    = "${boxen::config::datadir}/redis"
   $executable = "${boxen::config::home}/homebrew/bin/redis-server"
   $logdir     = "${boxen::config::logdir}/redis"
-  $port       = 16379
+  $port       = 6379
 }


### PR DESCRIPTION
Similar to https://github.com/boxen/puppet-mongodb/pull/5

Wouldn't it be better to assume the user wants to use the default redis port, and then they can fork and change it if they want to use a different port?

Thanks! :+1: 
