### PR TITLE
Want to overwrite redis::config::port by Hiera

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,7 +3,9 @@
 # Usage:
 #
 #     include redis::config
-class redis::config {
+class redis::config (
+  $port = 16379
+){
   require boxen::config
 
   $configdir  = "${boxen::config::configdir}/redis"
@@ -11,5 +13,4 @@ class redis::config {
   $datadir    = "${boxen::config::datadir}/redis"
   $executable = "${boxen::config::home}/homebrew/bin/redis-server"
   $logdir     = "${boxen::config::logdir}/redis"
-  $port       = 16379
 }


### PR DESCRIPTION
I want to use the automatic parameter lookup.
http://docs.puppetlabs.com/hiera/1/puppet.html#automatic-parameter-lookup
## Sample usage:

~/src/our-boxen/config/hiera.yaml

``` YAML

---
:backends:
  - yaml
:yaml:
  :datadir: '/opt/boxen/repo/hieradata'
:logger: console
:hierarchy:
  - common
```

~/src/our-boxen/hieradata/common.yaml

``` YAML

---
redis::config::port: 7777777
```
