### PR TITLE
Restart the redis service after config changes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,7 @@ class redis(
     executable    => $executable,
 
     servicename   => $servicename,
+    notify        => Service['redis'],
   }
 
   ~>

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -15,6 +15,7 @@ class redis::service(
   service { $servicename:
     ensure => $real_ensure,
     enable => $enable,
+    alias  => 'redis',
   }
 
   if $::operatingsystem == 'Darwin' {

--- a/spec/classes/redis__service_spec.rb
+++ b/spec/classes/redis__service_spec.rb
@@ -7,7 +7,7 @@ describe "redis::service" do
     let(:facts) { default_test_facts.merge(:operatingsystem => "Darwin") }
 
     it do
-      should contain_service("dev.redis")
+      should contain_service("dev.redis").with_alias('redis')
       should contain_service("com.boxen.redis").with_ensure(:stopped)
     end
   end
@@ -16,7 +16,7 @@ describe "redis::service" do
     let(:facts) { default_test_facts.merge(:operatingsystem => "Ubuntu") }
 
     it do
-      should contain_service("redis-server")
+      should contain_service("redis-server").with_alias('redis')
     end
   end
 end


### PR DESCRIPTION
Like it says on the box.

This requires the nasty hack of aliasing the service to a common name `redis` then notifying it directly because of http://projects.puppetlabs.com/issues/5191

cc @wfarr
