### PR TITLE
Update Darwin.yaml

### DIFF
--- a/data/Darwin.yaml
+++ b/data/Darwin.yaml
@@ -3,7 +3,7 @@ redis::configdir:   "%{::boxen::config::configdir}/redis"
 redis::datadir:     "%{::boxen::config::datadir}/redis"
 redis::logdir:      "%{::boxen::config::logdir}/redis"
 redis::host:        '127.0.0.1'
-redis::port:        '16379'
+redis::port:        '6379'
 redis::pidfile:     "%{::boxen::config::datadir}/redis/pid"
 redis::executable:  "%{::boxen::config::homebrewdir}/bin/redis-server"
 redis::package:     'boxen/brews/redis'


### PR DESCRIPTION
The default port on which all redis clients connect is 6379. Having to rewrite the config file each time running boxen is a pain. This change will ensure that redis runs on the port which requires the least end user configuration.
