### PR TITLE
upgrade redis to 2.8.21 to mitigate lua vulnerability

### DIFF
--- a/data/Darwin.yaml
+++ b/data/Darwin.yaml
@@ -7,5 +7,5 @@ redis::port:        '16379'
 redis::pidfile:     "%{::boxen::config::datadir}/redis/pid"
 redis::executable:  "%{::boxen::config::homebrewdir}/bin/redis-server"
 redis::package:     'boxen/brews/redis'
-redis::version:     '2.8.6-boxen1'
+redis::version:     '2.8.21-boxen1'
 redis::servicename: 'dev.redis'

--- a/files/brews/redis.rb
+++ b/files/brews/redis.rb
@@ -2,15 +2,10 @@ require 'formula'
 
 class Redis < Formula
   homepage 'http://redis.io/'
-  url 'http://download.redis.io/releases/redis-2.8.6.tar.gz'
-  sha1 '8680046580c75987961241f2e1e417c242b91a49'
+  url 'http://download.redis.io/releases/redis-2.8.21.tar.gz'
+  sha1 '52f619d3d301fc7ae498a1d4cb4d44ecebc5b0f9'
 
-  version '2.8.6-boxen1'
-
-  fails_with :llvm do
-    build 2334
-    cause 'Fails with "reference out of range from _linenoise"'
-  end
+  version '2.8.21-boxen1'
 
   def install
     # Architecture isn't detected correctly on 32bit Snow Leopard without help

--- a/spec/classes/redis__package_spec.rb
+++ b/spec/classes/redis__package_spec.rb
@@ -5,7 +5,7 @@ describe "redis::package" do
   let(:params) { {
     'ensure' => 'present',
     'package' => 'boxen/brews/redis',
-    'version' => '2.8.6-boxen1'
+    'version' => '2.8.21-boxen1'
   } }
 
   it do


### PR DESCRIPTION
The llvm issue here has been fixed upstream, so removing that `fails_with` block. This upgrade mitigates https://groups.google.com/forum/#!msg/redis-db/4Y6OqK8gEyk/Dg-5cejl-eUJ.