### PR TITLE
Fish Compatibility

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -35,10 +35,11 @@ class redis::config(
 
     ->
     boxen::env_script { 'redis-fish':
-      ensure    => $ensure,
-      content   => template('redis/darwin/env.fish.erb'),
-      priority  => 'lower',
-      extension => 'fish',
+      ensure     => $ensure,
+      content    => template('redis/darwin/env.fish.erb'),
+      priority   => 'lower',
+      scriptname => 'redis',
+      extension  => 'fish',
     }
 
     boxen::env_script { 'redis':

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -34,6 +34,13 @@ class redis::config(
     }
 
     ->
+    boxen::env_script { 'redis-fish':
+      ensure    => $ensure,
+      content   => template('redis/darwin/env.fish.erb'),
+      priority  => 'lower',
+      extension => 'fish',
+    }
+
     boxen::env_script { 'redis':
       ensure   => $ensure,
       content  => template('redis/darwin/env.sh.erb'),

--- a/templates/darwin/env.fish.erb
+++ b/templates/darwin/env.fish.erb
@@ -1,0 +1,6 @@
+# Let the env know where Redis runs.
+
+set -g -x BOXEN_REDIS_HOST <%= @host %>
+set -g -x BOXEN_REDIS_PORT <%= @port %>
+
+set -g -x BOXEN_REDIS_URL "redis://$BOXEN_REDIS_HOST:$BOXEN_REDIS_PORT/"


### PR DESCRIPTION
Adds a Fish version of the env script. 

Relies on boxen/puppet-boxen#138 (for the `extension` argument to `env_script`).
