### PR TITLE
Update hiera config version to 3.0.7-boxen1

### DIFF
--- a/data/Darwin.yaml
+++ b/data/Darwin.yaml
@@ -7,5 +7,5 @@ redis::port:        '16379'
 redis::pidfile:     "%{::boxen::config::datadir}/redis/pid"
 redis::executable:  "%{::boxen::config::homebrewdir}/bin/redis-server"
 redis::package:     'boxen/brews/redis'
-redis::version:     '3.0.5-boxen1'
+redis::version:     '3.0.7-boxen1'
 redis::servicename: 'dev.redis'


### PR DESCRIPTION
Updates the config to use 3.0.7-boxen1 as all the other files point to in the 4.0.1 tag. I found that running this module the first time worked fine but subsequent runs try to downgrade to 3.0.5-boxen1.
