### PR TITLE
Fixes Discrepancy Between Homebrew and Hiera

### DIFF
--- a/data/Darwin.yaml
+++ b/data/Darwin.yaml
@@ -7,5 +7,5 @@ redis::port:        '16379'
 redis::pidfile:     "%{::boxen::config::datadir}/redis/pid"
 redis::executable:  "%{::boxen::config::homebrewdir}/bin/redis-server"
 redis::package:     'boxen/brews/redis'
-redis::version:     '3.0.5-boxen1'
+redis::version:     '3.0.7-boxen1'
 redis::servicename: 'dev.redis'


### PR DESCRIPTION
Homebrew thinks it's installing `3.0.7-boxen1` (and it does), but Hiera thinks it's installing `3.0.5-boxen1`. This doesn't appear to have any major consequences, but it does introduce noise.

This commit puts Hiera on the same page as Homebrew.
